### PR TITLE
Add PHPUnit support

### DIFF
--- a/bin/phpunit
+++ b/bin/phpunit
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+source $(dirname $0)/../lib/bowline/bowline
+assert_running
+assert_composer
+
+docker exec -it ${web} sudo -iu www-data /var/www/vendor/bin/phpunit "$@"

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "description": "The Project.",
   "require": {
     "drush/drush": "6.*",
-    "drupal/coder": "~8.2"
+    "drupal/coder": "~8.2",
+    "phpunit/phpunit": "4.5.*"
   }
 }


### PR DESCRIPTION
This adds PHPUnit support to Bowline.

n.b. I'm using this with a Drupal 6 site at the moment, and had to add the following lines for phpunit to work:

``` php
define('DRUPAL_ROOT', getcwd() . '/docroot');
chdir(DRUPAL_ROOT);
require_once DRUPAL_ROOT . '/includes/bootstrap.inc';
$_SERVER['REMOTE_ADDR'] = '127.0.0.1';

// Bootstrap Drupal.
drupal_bootstrap(DRUPAL_BOOTSTRAP_FULL);
```

`chdir()` being the key one.

Additionally, I need to run the tests from the repo root. If I cd to the docroot, then for some reason underscores in my module directory names get converted to slashes (`/`).