### PR TITLE
Update readme: change fig to docker-compose #23

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@
 ## Requirements
 1. [Docker](https://www.docker.com/)
   - Make sure you can successfully run docker commands without sudo. See [Ubuntu example](https://docs.docker.com/installation/ubuntulinux/#giving-non-root-access).
-1. [Fig](http://www.fig.sh/)
+1. [Docker Compose](http://docs.docker.com/compose/)
 
 See also the [wiki](https://github.com/davenuman/bowline/wiki) for [platform-specific instructions](https://github.com/davenuman/bowline/wiki/Platform-specific-instructions).
 


### PR DESCRIPTION
This updates the requirements section of the project readme, changing Fig to Docker Compose (Issue #23)

Fig has been replaced by Docker Compose, and it looks like #16 addresses that.