### PR TITLE
Edit my.cnf, increase wait_timeout

### DIFF
--- a/.docker/etc/my.cnf
+++ b/.docker/etc/my.cnf
@@ -1,6 +1,6 @@
 # The MySQL database server configuration file.
 [mysqld]
-wait_timeout = 1200
+wait_timeout = 6000
 key_buffer_size = 786M
 max_allowed_packet = 64M
 table_open_cache = 512


### PR DESCRIPTION
Importing a large-ish database, I was getting everyone's favorite MySQL error:
`ERROR 2006 (HY000): MySQL server has gone away`
Increasing the wait_timeout value resolves the issue, and I think this works as a better default value for a development sandbox.