### PR TITLE
Add patch-contrib command.

### DIFF
--- a/bin/patch-contrib
+++ b/bin/patch-contrib
@@ -2,5 +2,5 @@
 # Rebuilds the patches applied to the repo. Won't build core.
 LOCAL_ROOT=$(git rev-parse --show-toplevel)
 cd $LOCAL_ROOT/docroot/sites/all
-drush make /var/www/docroot/patches.make -y --no-core --no-gitinfofile --contrib-destination=./docroot/sites/all --concurrency=8
+drush make /var/www/docroot/patches.make -y --no-core --no-gitinfofile --contrib-destination=./docroot/sites/all --concurrency=8 --no-cache
 cd $LOCAL_ROOT/

--- a/bin/patch-contrib
+++ b/bin/patch-contrib
@@ -1,0 +1,6 @@
+#! /bin/bash -e
+# Rebuilds the patches applied to the repo. Won't build core.
+LOCAL_ROOT=$(git rev-parse --show-toplevel)
+cd $LOCAL_ROOT/docroot/sites/all
+drush make /var/www/docroot/patches.make -y --no-core --no-gitinfofile --contrib-destination=./docroot/sites/all --concurrency=8
+cd $LOCAL_ROOT/


### PR DESCRIPTION
An easy way to run a finicky command to patch only the contrib modules using a patch list.
