### PR TITLE
Update bowline support for Version 2 Docker Compose

### DIFF
--- a/bin/backup
+++ b/bin/backup
@@ -3,7 +3,7 @@
 source $(dirname $0)/../lib/bowline/bowline
 
 FILENAME=${GIT_ROOT}/.${GIT_BRANCH}.sql
-docker exec -i ${web} mysqldump --host=dbhost --user=dbuser --password=dbpass drupal > $FILENAME
+docker exec --user www-data -i ${web} mysqldump --host=dbhost --user=dbuser --password=dbpass drupal > $FILENAME
 gzip $FILENAME
 
 echo ""

--- a/bin/build
+++ b/bin/build
@@ -17,5 +17,11 @@ $DCOMPOSE up -d --no-recreate
 EXIT=$?
 echo -e "\033[m Exit Status: $EXIT"
 
+# Connect network manually if not connected
+if [ ! "$(docker inspect proxy | grep ${BOWLINE}_default)" ];then
+  echo "Connecting network ${BOWLINE}_default to proxy..."
+  docker network connect ${BOWLINE}_default proxy
+fi
+
 bowline
 exit $EXIT

--- a/bin/drupal
+++ b/bin/drupal
@@ -3,4 +3,4 @@
 source $(dirname $0)/../lib/bowline/bowline
 assert_running
 
-docker exec -it ${web} sudo -iu www-data /var/www/vendor/bin/drupal --root=/var/www/docroot $@
+docker exec --user www-data -it ${web} /var/www/vendor/bin/drupal --root=/var/www/docroot $@

--- a/bin/refresh_proxy
+++ b/bin/refresh_proxy
@@ -9,5 +9,11 @@ $DCOMPOSE up -d web
 EXIT=$?
 echo -e "\033[m Exit Status: $EXIT"
 
+# Connect network manually if not connected
+if [ ! "$(docker inspect proxy | grep ${BOWLINE}_default)" ];then
+  echo "Connecting network ${BOWLINE}_default to proxy..."
+  docker network connect ${BOWLINE}_default proxy
+fi
+
 bowline
 exit $EXIT

--- a/bin/settings_init
+++ b/bin/settings_init
@@ -16,11 +16,11 @@ if [ ! -d "${settingspath}" ];then
   version="drupal-7"
   if [ "${drupal}" = "8" ];then
     version="drupal-8"
-    composer require drush/drush:8.*
   fi
+  composer require drush/drush:8.*
   /var/www/vendor/bin/drush dl --destination=/var/www $version
   [ -d "docroot" ] && mv -v docroot old-docroot
-  mv -v drupal-* docroot
+  mv -v drupal-${drupal}* docroot
 fi
 
 if [ ! -f "${settingspath}/settings.php" ];then

--- a/bin/settings_init
+++ b/bin/settings_init
@@ -2,13 +2,7 @@
 
 source $(dirname $0)/../lib/bowline/bowline
 
-# Only run fix-perms when not in container since it runs docker-exec inside
-if [ "$context" == "host" ];then
-  fix-perms
-fi;
-
 enter_container
-
 settingspath=/var/www/docroot/sites/default
 cd /var/www
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,60 +1,62 @@
-# Storage
-filestore:
-  image: civicactions/sshd
-  environment:
-    - HOST_USER=${HOST_UID}:${HOST_GID}
-  volumes:
-    - /var/www
-db:
-  image: mariadb:10.1
-  environment:
-    - MYSQL_ROOT_PASSWORD=root
-    - MYSQL_USER=dbuser
-    - MYSQL_PASSWORD=dbpass
-    - MYSQL_DATABASE=drupal
-    - MYSQL_HOME=/etc
-  volumes:
-    - ./.docker/etc/my.cnf:/etc/my.cnf
-  hostname: dbhost
-  expose:
-    - "3306"
+version: "2"
+services:
+  # Storage
+  filestore:
+    image: civicactions/sshd
+    environment:
+      - HOST_USER=${HOST_UID}:${HOST_GID}
+    volumes:
+      - /var/www
+  db:
+    image: mariadb:10.1
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_USER=dbuser
+      - MYSQL_PASSWORD=dbpass
+      - MYSQL_DATABASE=drupal
+      - MYSQL_HOME=/etc
+    volumes:
+      - ./.docker/etc/my.cnf:/etc/my.cnf
+    hostname: dbhost
+    expose:
+      - "3306"
 
-# Services
-php:
-  image: davenuman/bowline-centos
-  command: php-fpm
-  environment:
-    - COMPOSER_HOME=/.composer
-    - HOST_USER=${HOST_UID}:${HOST_GID}
-  expose:
-    - "9000"
-  volumes_from:
-    - filestore
-  links:
-    - db:dbhost
-  hostname: php_host
-web:
-  image: davenuman/bowline-centos
-  command: httpd -D FOREGROUND -e debug
-  environment:
-    - HOST_USER=${HOST_UID}:${HOST_GID}
-  expose:
-    - "80"
-  links:
-    - db:dbhost
-    - php:php_host
-  volumes_from:
-    - filestore
-  hostname: drupal
+  # Services
+  php:
+    image: davenuman/bowline-centos
+    command: php-fpm
+    environment:
+      - COMPOSER_HOME=/.composer
+      - HOST_USER=${HOST_UID}:${HOST_GID}
+    expose:
+      - "9000"
+    volumes_from:
+      - filestore
+    links:
+      - db:dbhost
+    hostname: php_host
+  web:
+    image: davenuman/bowline-centos
+    command: httpd -D FOREGROUND -e debug
+    environment:
+      - HOST_USER=${HOST_UID}:${HOST_GID}
+    expose:
+      - "80"
+    links:
+      - db:dbhost
+      - php:php_host
+    volumes_from:
+      - filestore
+    hostname: drupal
 
-# File synchronizing
-sync:
-  image: civicactions/bg-sync
-  volumes:
-    - .:/source
-  volumes_from:
-    - filestore
-  environment:
-    - SYNC_DESTINATION=/var/www
-    - SYNC_WAIT=20
-    - SYNC_VERBOSE=1
+  # File synchronizing
+  sync:
+    image: civicactions/bg-sync
+    volumes:
+      - .:/source
+    volumes_from:
+      - filestore
+    environment:
+      - SYNC_DESTINATION=/var/www
+      - SYNC_WAIT=20
+      - SYNC_VERBOSE=1

--- a/lib/bowline/bowline
+++ b/lib/bowline/bowline
@@ -8,6 +8,48 @@ fi
 
 get_container_name () { echo "${SLUG}_${1}_1"; }
 
+# Parses YML file and outputs key=value for each depth.
+# Usage: $(parse_yml filename prefix_to_add_to_key)
+#
+# Output will have for example:
+#  PREFIX_firstdepthvar1=value
+#  PREFIX_firstdepthvar2__seconddepthvar2=value
+#  PREFIX_firstdepthvar3__seconddepthvar3__thirddepthvar3=value
+parse_yml () {
+  local prefix=$2
+  local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+  sed -ne "s|^\($s\):|\1|" \
+      -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
+      -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("__")}
+         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+      }
+   }'
+}
+
+# Parses docker-compose.yml and outputs the container names.
+list_containers () {
+  yml_output="$(parse_yml docker-compose.yml DOCKER_COMPOSE_YML_)"
+  eval $yml_output
+  IFS=$'\n' read -rd '' -a yml_output_vars <<<"$yml_output"
+  for i in "${yml_output_vars[@]}"
+  do
+    key=${i%%=*}
+    if [ "$DOCKER_COMPOSE_YML_version" == "2" ]; then
+      if [[ $key =~ ^DOCKER_COMPOSE_YML_services__(.*)__image ]]; then
+        echo ${BASH_REMATCH[1]}
+      fi
+    else
+      echo $key
+    fi
+  done
+}
+
 check_build() { unset CONTAINERS_BUILT; [ "$(docker ps -a | grep ${SLUG}_web)" ] && CONTAINERS_BUILT="true"; }
 
 # Set basic env variables.
@@ -42,16 +84,14 @@ bowline_init () {
   ### @@ Note, everytime the ip changes the following should run
   # Add some useful container env
   check_build
-  list_containers=$(grep '^\S*:' docker-compose.yml)
   unset containers
-  for c in $list_containers; do
-    name="${c%:}"
+  for name in $(list_containers); do
     container_name="$(get_container_name ${name})"
     # Set variables such as $web and $db from the docker-compose.yml.
     export "${name}=${container_name}"
     # Set IP addresses if they are available.
     if [ "$CONTAINERS_BUILT" ];then
-      local ip="$(docker inspect --format='{{.NetworkSettings.IPAddress}}' ${container_name})"
+      local ip="$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${container_name})"
       [ "$ip" ] && export "${name}_ip"=$ip || export "${name}_ip"="not running"
     else
       export "${name}_ip"="not built"
@@ -85,9 +125,11 @@ assert_proxy () {
 
   # Configure host for proxy.
   local proxyconf_file=".bowline/docker-compose.proxyconf.yml"
-  echo -e "web:\n  labels:" > $proxyconf_file
-  echo -e "    - traefik.backend=${SLUG}" >> $proxyconf_file
-  echo -e "    - traefik.frontend.rule=Host:${WEB_DOMAIN}" >> $proxyconf_file
+  echo -e "version: \"2\"" > $proxyconf_file
+  echo -e "services:" >> $proxyconf_file
+  echo -e "  web:\n    labels:" >> $proxyconf_file
+  echo -e "      - traefik.backend=${SLUG}" >> $proxyconf_file
+  echo -e "      - traefik.frontend.rule=Host:${WEB_DOMAIN}" >> $proxyconf_file
 
   DCOMPOSE="$DCOMPOSE -f docker-compose.yml -f $proxyconf_file"
 }
@@ -114,7 +156,7 @@ enter_container () {
     return
   fi
   assert_running
-  docker exec -it $(get_container_name web) /var/www/bin/$(basename $0) $@
+  docker exec -it --user www-data $(get_container_name web) /var/www/bin/$(basename $0) $@
   EXIT=$?
   echo Exit Status: $EXIT
   exit $EXIT

--- a/lib/bowline/install.sh
+++ b/lib/bowline/install.sh
@@ -61,6 +61,8 @@ if [ -e "docroot/core/CHANGELOG.txt" ];then
   echo -e "Drush updated for drupal 8.\n"
 fi
 
+fix-perms
+
 echo "If you are importing an existing database, save the database export file as .snapshot.sql.gz in this project root directory, then run the 'import' command. If not, you can continue with installing Drupal."
 read_continue "Would you like to perform a fresh Drupal site install? [Y/n]"
 drush si --sites-subdir=default --site-name=Bowline-Site-Install

--- a/lib/rigging/behat/bin/behat
+++ b/lib/rigging/behat/bin/behat
@@ -5,4 +5,4 @@ assert_running
 assert_composer
 
 echo "Running 'behat $@' inside container"
-docker exec -it ${web} sudo -iu www-data ./vendor/bin/behat -c tests/behat/local.yml "$@"
+docker exec --user www-data -it ${web} ./vendor/bin/behat -c tests/behat/local.yml "$@"

--- a/lib/rigging/codeception/bin/codecept
+++ b/lib/rigging/codeception/bin/codecept
@@ -4,4 +4,4 @@ source $(dirname $0)/../lib/bowline/bowline
 assert_running
 assert_composer
 
-docker exec -it ${web} sudo -iu www-data /var/www/vendor/bin/codecept "$@"
+docker exec --user www-data -it ${web} /var/www/vendor/bin/codecept "$@"

--- a/lib/rigging/phpunit/bin/phpunit
+++ b/lib/rigging/phpunit/bin/phpunit
@@ -4,4 +4,4 @@ source $(dirname $0)/../lib/bowline/bowline
 assert_running
 assert_composer
 
-docker exec -it ${web} sudo -iu www-data /var/www/vendor/bin/phpunit "$@"
+docker exec --user www-data -it ${web} /var/www/vendor/bin/phpunit "$@"


### PR DESCRIPTION
- Updates Docker Compose to Version 2
- Fixes Drupal 7 composer install of drush prior to using it
- Adds docker exec user of www-data to all calls
- Adjusts proxy to add XXX_default network since [Version 2] (https://docs.docker.com/compose/compose-file/compose-versioning/#version-2) networking is different now in Docker

This may need to be a PR against a new branch to starts beta 2.0 features