### PR TITLE
Modify import script, disable transaction commits during import.

### DIFF
--- a/bin/import
+++ b/bin/import
@@ -73,6 +73,8 @@ $MYSQL -ss -e 'SELECT concat("DROP TABLE `", TABLE_NAME, "`;") FROM information_
 echo "Tables dropped.  Beginning import."
 
 # Import.
+$MYSQL -e "SET autocommit=0;"
 pv $DBFILE | gunzip | $MYSQL
+$MYSQL -e "COMMIT; SET autocommit=1;"
 
 echo "# DB import complete, recommend running 'drush updb'."


### PR DESCRIPTION
Minor change to the import script based on suggestions here: https://dba.stackexchange.com/questions/98814/mysql-dump-import-incredibly-slow-on-my-developers-machine

I'm seeing significant improvements to speed importing databases on a Linux (Fedora) system.